### PR TITLE
Use the updated component-domify array of element

### DIFF
--- a/client/item-view/index.js
+++ b/client/item-view/index.js
@@ -22,7 +22,8 @@ module.exports = ItemView;
  */
 
 function ItemView(item) {
-  View.call(this, item, domify(html));
+  var el = domify(html);
+  View.call(this, item, el[0]);
   this.classes = classes(this.el);
   item.on('change complete', this.toggleCompleteClass.bind(this));
   this.bind('click .x', 'remove');


### PR DESCRIPTION
Fixed the bug when creating a view object. Component domify now always return an array of element so we have to pass the element inside the array that is returned by domify when instantiating a new component-view object.
