### PR TITLE
Update routes to be consistent with component-model's plural convention.

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,9 +18,9 @@ app.use(express.static(__dirname + '/build'));
 // items
 
 app.get('/items', items.all);
-app.post('/item', items.create);
-app.put('/item/:id', items.update);
-app.del('/item/:id', items.remove);
+app.post('/items', items.create);
+app.put('/items/:id', items.update);
+app.del('/items/:id', items.remove);
 
 // catch-all
 


### PR DESCRIPTION
This addresses [issue #14](https://github.com/component/todo/issues/14). It appears that component-model was updated to use a plural model by convention, thereby breaking the create, update and remove endpoints in the app.
